### PR TITLE
Changed reshaping of tracerdata.h5py 

### DIFF
--- a/crest.py
+++ b/crest.py
@@ -706,7 +706,7 @@ class ArepoTracerOutput:
 		# if the flag does not exist, set it to True - previously eps_ph was always written
 		self.flag_photon_energy_density = hf['Header'].attrs.get('PhotonEnergyDensityFlag', True)
 
-		self.AllIDs = hf['Header/AllTracerParticleIDs'][()]
+		self.AllIDs = np.sort(hf['Header/AllTracerParticleIDs'][()])
 
 		self.nPart = self.AllIDs.shape[0]
 
@@ -756,6 +756,12 @@ class ArepoTracerOutput:
 			self.n_gas = hf['TracerData/Density'][()]
 			self.u_therm = hf['TracerData/InternalEnergy'][()]
 
+			self.next_timestep_start_index = hf['TracerData']['NextTimestepStartIndex'][()]
+			# insert 0th index for indices_i
+			self.indices_i = np.insert(self.next_timestep_start_index, 0, 0)
+			self.indices_f = self.next_timestep_start_index
+
+
 			if self.flag_photon_energy_density:
 				self.eps_photon = hf['TracerData/PhotonEnergyDensity'][()]
 
@@ -789,53 +795,82 @@ class ArepoTracerOutput:
 				print("CRE_ANALYSIS: reshape_output=True")
 				print("CRE_ANALYSIS: reshaping Arepo tracer output into shapes of (nSnap, nPart)\n")
 
-				self.ID = self.ID.reshape(self.nSnap, self.nPart)
-				self.pos = self.pos.reshape(self.nPos, self.nPart, 3)
-				self.B = self.B.reshape(self.nSnap, self.nPart, 3)
-				self.n_gas = self.n_gas.reshape(self.nSnap, self.nPart)
-				self.u_therm = self.u_therm.reshape(self.nSnap, self.nPart)
+				# reshape the data so that it has the shape (nSnap, nPart)
+				def reshape_arrays(array, is_3d=False):
+					snap_arrays = [array[start:end, :] if is_3d else array[start:end] for start, end in zip(self.indices_i, self.indices_f)]
+					IDs_current_tracers = [self.ID[start:end] for start, end in zip(self.indices_i, self.indices_f)]
+
+					if is_3d:
+						output_shape = (len(snap_arrays), self.nPart, 3)
+					else:
+						output_shape = (len(snap_arrays), self.nPart)
+
+
+					output_array = np.full(output_shape, np.nan)
+
+					for i, (subarray, current_tracers) in enumerate(zip(snap_arrays, IDs_current_tracers)):
+						if len(subarray) == 0:
+							continue
+
+						sorted = np.argsort(current_tracers)
+						indices = np.where(np.isin(self.AllIDs, current_tracers))[0]
+
+						if is_3d:
+							output_array[i, indices, :] = subarray[sorted]
+						else:
+							output_array[i, indices] = subarray[sorted]
+
+					return output_array
+				
+
+
+				self.pos = reshape_arrays(self.pos, is_3d=True)
+				self.B = reshape_arrays(self.B, is_3d=True)
+				self.n_gas = reshape_arrays(self.n_gas)
+				self.u_therm = reshape_arrays(self.u_therm)
 
 				if self.flag_photon_energy_density:
-					self.eps_photon = self.eps_photon.reshape(self.nSnap, self.nPart)
+					self.eps_photon = reshape_arrays(self.eps_photon)
 
 				if self.flag_cosmic_ray_shock_acceleration:
-					self.ShockFlag = self.ShockFlag.reshape(self.nSnap, self.nPart)
+				# LJ: TODO: check with Joe how to do this
+					self.ShockFlag = reshape_arrays(self.ShockFlag)
 
-					zeros = np.zeros([self.nSnap, self.nPart, 3])
-					zeros[np.where(self.ShockFlag > 1)] = self.ShockDir
-					self.ShockDir = zeros
+					# zeros = np.zeros([self.nSnap, self.nPart, 3])
+					# zeros[np.where(self.ShockFlag > 1)] = self.ShockDir
+					# self.ShockDir = zeros
 
-					zeros = np.zeros([self.nSnap, self.nPart])
-					zeros[np.where(self.ShockFlag > 1)] = self.eps_CRp_acc
-					self.eps_CRp_acc = zeros
-					zeros[np.where(self.ShockFlag > 1)] = self.n_gasPreShock
-					self.n_gasPreShock = zeros
-					zeros[np.where(self.ShockFlag > 1)] = self.n_gasPostShock
-					self.n_gasPostShock = zeros
-					zeros[np.where(self.ShockFlag > 1)] = self.VShock
-					self.VShock = zeros
-					zeros[np.where(self.ShockFlag > 1)] = self.timeShockCross
-					self.timeShockCross = zeros
+					# zeros = np.zeros([self.nSnap, self.nPart])
+					# zeros[np.where(self.ShockFlag > 1)] = self.eps_CRp_acc
+					# self.eps_CRp_acc = zeros
+					# zeros[np.where(self.ShockFlag > 1)] = self.n_gasPreShock
+					# self.n_gasPreShock = zeros
+					# zeros[np.where(self.ShockFlag > 1)] = self.n_gasPostShock
+					# self.n_gasPostShock = zeros
+					# zeros[np.where(self.ShockFlag > 1)] = self.VShock
+					# self.VShock = zeros
+					# zeros[np.where(self.ShockFlag > 1)] = self.timeShockCross
+					# self.timeShockCross = zeros
 
-					if self.flag_cosmic_ray_sn_injection:
-						zeros[np.where(self.ShockFlag > 1)] = self.theta
-						self.timeShockCross = zeros
+					# if self.flag_cosmic_ray_sn_injection:
+					# 	zeros[np.where(self.ShockFlag > 1)] = self.theta
+					# 	self.timeShockCross = zeros
 
-					self.ShockDir = self.ShockDir.reshape(self.nSnap, self.nPart, 3)
-					self.eps_CRp_acc = self.eps_CRp_acc.reshape(self.nSnap, self.nPart)
-					self.n_gasPreShock = self.n_gasPreShock.reshape(self.nSnap, self.nPart)
-					self.n_gasPostShock = self.n_gasPostShock.reshape(self.nSnap, self.nPart)
-					self.VShock = self.VShock.reshape(self.nSnap, self.nPart)
-					self.timeShockCross = self.timeShockCross.reshape(self.nSnap, self.nPart)
+					# self.ShockDir = self.ShockDir.reshape(self.nSnap, self.nPart, 3)
+					# self.eps_CRp_acc = self.eps_CRp_acc.reshape(self.nSnap, self.nPart)
+					# self.n_gasPreShock = self.n_gasPreShock.reshape(self.nSnap, self.nPart)
+					# self.n_gasPostShock = self.n_gasPostShock.reshape(self.nSnap, self.nPart)
+					# self.VShock = self.VShock.reshape(self.nSnap, self.nPart)
+					# self.timeShockCross = self.timeShockCross.reshape(self.nSnap, self.nPart)
 
-					if self.flag_cosmic_ray_sn_injection:
-						self.theta = self.theta.reshape(self.nSnap, self.nPart)
+					# if self.flag_cosmic_ray_sn_injection:
+						# self.theta = self.theta.reshape(self.nSnap, self.nPart)
 
 				if self.flag_cosmic_ray_sn_injection:
-					self.eps_CRp_inj = self.eps_CRp_inj.reshape(self.nSnap, self.nPart)
+					self.eps_CRp_inj = reshape_arrays(self.eps_CRp_inj)
 
 				if self.flag_comoving_integration_on:
-					self.dtValues = self.dtValues.reshape(self.nSnap)
+					self.dtValues = reshape_arrays(self.dtValues)	
 
 		if verbose:
 			print("Data was read successfully")

--- a/misc/get_volumes.py
+++ b/misc/get_volumes.py
@@ -119,6 +119,6 @@ if __name__ == "__main__":
 
           for snap_no in range(25+1):
               print("    Snap no: {}".format(snap_no))
-              crest_file   = CrestSnapshot("./{}/{}/{}{:03d}.dat".format(sim_dir[i], mach_variation[j], cre_filebase, snap_no), high_tracer_number=True)
+              crest_file = CrestSnapshot("./{}/{}/{}{:03d}.dat".format(sim_dir[i], mach_variation[j], cre_filebase, snap_no), high_tracer_number=True)
 
               tracer_vol = load_tracer_volumes(snap_no, sim_dir[i], mach_variation[j], crest_file)

--- a/misc/get_volumes.py
+++ b/misc/get_volumes.py
@@ -1,0 +1,124 @@
+# To be run in /lustre/joseph/Sims/ShocktubeSims/
+# script saves volumes for later reading
+
+import os
+import freud
+import numpy as np
+import astropy.units as units
+from mpi4py import MPI
+from crest import *
+
+# ==============================================================================
+# Start up with parameter loading
+comm = MPI.COMM_WORLD
+size = comm.Get_size()
+rank = comm.Get_rank()
+freud.parallel.set_num_threads(size)
+
+# ==============================================================================
+# Setting size of high-res box used in simulation (in kpc)
+# (will be used to set size of Freud box, within which volumes are found)
+
+#number of gas cells (each direction)
+nx = 90
+ny = 60
+nz = 60
+
+#box size (original size)
+long_x = nx/ny * 4
+long_y = 1.
+long_z = 1.
+
+box_size = 300
+
+sx = long_x * box_size
+sy = long_y * box_size
+sz = long_z * box_size
+
+
+# ==============================================================================
+
+# Crest snapshot prefix
+cre_filebase = "Snap_CRe_"
+
+# Simulation variations and directories
+mach_variation   = ["output_crest", "output_crest--mach-no-3"]
+
+sim_dir = \
+[
+#"Flat-noCRs-ramped_buffer-cartesian-equal_density",
+"Flat-noCRs-ramped_buffer-cartesian-equal_density-b_rms_1.6e-07",
+#"Turb-noCRs-ramped_buffer-cartesian-equal_density-inj_150.0-sigma_3.9e-07-powerlaw_-3.666667",
+#"Turb-noCRs-ramped_buffer-cartesian-equal_density-inj_150.0-sigma_3.9e-07-powerlaw_-3.666667-b_rms_1.6e-07",
+#"Turb-noCRs-ramped_buffer-cartesian-equal_density-inj_150.0-sigma_1.9e-07-powerlaw_-3.666667-b_rms_1.6e-07",
+#"Turb-noCRs-ramped_buffer-cartesian-equal_density-inj_150.0-sigma_7.7e-07-powerlaw_-3.666667-b_rms_1.6e-07",
+#"Turb-noCRs-ramped_buffer-cartesian-equal_density-inj_150.0-sigma_3.9e-07-powerlaw_-2.833333-b_rms_1.6e-07",
+#"Turb-noCRs-ramped_buffer-cartesian-equal_density-inj_150.0-sigma_3.9e-07-powerlaw_-5.333333-b_rms_1.6e-07",
+#"Turb-noCRs-ramped_buffer-cartesian-equal_density-inj_75.0-sigma_3.9e-07-powerlaw_-3.666667-b_rms_1.6e-07",
+#"Turb-noCRs-ramped_buffer-cartesian-equal_density-inj_200.0-sigma_3.9e-07-powerlaw_-3.666667-b_rms_1.6e-07"]
+]
+
+def tracer_volumes(snap_no, crest_file):
+  """
+  Use Freud functionality to return Voronoi volumes
+  Return: volume associated with each (injected) tracer
+  """
+
+  # Convert tracer positions from "cm" to "kpc"
+  tracer_pos = (crest_file.pos * units.cm).to(units.kpc).value
+
+  # Centre the box on [0,0,0]
+  tracer_pos = np.subtract(tracer_pos, [sx/2, sy/2, sz/2])
+
+  # Create "Freud" box
+  box = freud.box.Box(Lx=sx, Ly=sy, Lz=sz)
+
+  # Compute Voronoi volumes
+  voro = freud.locality.Voronoi()
+  voro.compute((box, tracer_pos))
+  tracer_vol = np.copy(voro.volumes)
+
+  MPI.Finalize()
+
+  return tracer_vol
+
+
+def load_tracer_volumes(snap_no, directory, mach_variation, crest_file):
+    """
+    Load volume data or create and save if not available
+    """
+
+    # Path where volume data is saved
+    volume_dir = directory + "/" + mach_variation + "/volumes/"
+    volume_filename = "volume_{:03d}.npy".format(snap_no)
+
+    # Make path if it doesn't exist
+    if not(os.path.exists(volume_dir)):
+        os.makedirs(volume_dir)
+
+    # If the file exists, load it. Otherwise, make the data and save it.
+    if not(os.path.exists(volume_dir + volume_filename)):
+
+        tracer_vol = tracer_volumes(snap_no, crest_file)
+        np.save(volume_dir + volume_filename, tracer_vol)
+    else:
+        tracer_vol = np.load(volume_dir + volume_filename)
+
+    return tracer_vol
+
+
+if __name__ == "__main__":
+  """
+  Loop over directories and save tracer data for all snapshots
+  """
+  for i in range(len(sim_dir)):
+      print("Reading from: {}".format(sim_dir[i]))
+
+      for j in range(2):
+          print("  Current run variation: {}".format(mach_variation[j]))
+
+          for snap_no in range(25+1):
+              print("    Snap no: {}".format(snap_no))
+              crest_file   = CrestSnapshot("./{}/{}/{}{:03d}.dat".format(sim_dir[i], mach_variation[j], cre_filebase, snap_no), high_tracer_number=True)
+
+              tracer_vol = load_tracer_volumes(snap_no, sim_dir[i], mach_variation[j], crest_file)


### PR DESCRIPTION
Hi both,

This reshaping can be turned on and off.
I checked the test pipeline with this branch and did not get any errors.
This now works for different number of tracers at different times. It creates arrays for each quantity for each timestep, of the total number of tracers that exist at the end of the simulation (given in 'Header/AllTracerParticleIDs') with NaNs where the tracer was not active or did not exist. This is pretty useful to plot tracer diagnostics without doing index manipulations & is much faster than for loops.
**Warning:** I have not applied this reshaping to the shock data - it is commented out. I guess it should be straightforward to do this a similar approach to the one I used, but I am not familiar enough with the way this is done. Maybe a job for Joe whenever you have time?

Let me know,
Léna
